### PR TITLE
Set winner when marking a bet as completed

### DIFF
--- a/lib/data/ActionButton.dart
+++ b/lib/data/ActionButton.dart
@@ -7,6 +7,7 @@ class ActionButton {
     @required this.color,
     @required this.textColor,
     @required this.onPressed,
+    @required this.isFlat,
     this.iconStyle,
   });
 
@@ -20,8 +21,9 @@ class ActionButton {
   final Color textColor;
   final IconStyle iconStyle;
   final Function onPressed;
+  final bool isFlat;
 
-  ButtonTheme generateButton() {
+  ButtonTheme generateButton({Function callback}) {
     final Wrap buttonContent = Wrap(
       spacing: 2.0,
       alignment: WrapAlignment.center,
@@ -29,6 +31,15 @@ class ActionButton {
       children: <Widget>[Text(text, style: TextStyle(fontSize: textSize, color: textColor)),
       ],
     );
+    final Function pressedFn = () {
+      onPressed();
+      if (callback != null) {
+        callback();
+      }
+    };
+    final MaterialButton button = isFlat ?
+      FlatButton(onPressed: pressedFn, child: buttonContent) :
+      RaisedButton(onPressed: pressedFn, child: buttonContent);
     if (iconStyle != null) {
       buttonContent.children.insert(
           0,
@@ -40,7 +51,7 @@ class ActionButton {
       buttonColor: color,
       padding: EdgeInsets.symmetric(horizontal: horizontalPadding),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(buttonRadius)),
-      child: RaisedButton(onPressed: onPressed, child: buttonContent),
+      child: button,
     );
   }
 }

--- a/lib/mixins/WidgetHelper.dart
+++ b/lib/mixins/WidgetHelper.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:long_term_bets/data/ActionButton.dart';
+import 'package:long_term_bets/data/IconStyle.dart';
 import 'package:long_term_bets/styles/AppColors.dart';
 mixin WidgetHelper {
   Container buildDividedContainer(bool isBig, Widget child, {bool isLast = false}) {
@@ -23,4 +25,40 @@ mixin WidgetHelper {
       builder: (BuildContext bc) => child,
     );
   }
+
+Future<void> showAlert(
+  BuildContext context,
+  String title,
+  Widget child,
+  List<ActionButton> actions,
+) async {
+  final Function dismissAlert = () => Navigator.of(context).pop();
+
+  final List<ButtonTheme> actionButtons = actions.map((ActionButton button) =>
+    button.generateButton(callback: dismissAlert)
+  ).toList();
+
+  actionButtons.add(ActionButton(
+    isFlat: true,
+    onPressed: dismissAlert,
+    text: 'Discard',
+    textColor: AppColors.buttonText,
+    color: AppColors.transparent,
+    iconStyle: IconStyle(icon: Icons.keyboard_backspace, color: AppColors.buttonText)
+    ).generateButton());
+
+  return showDialog<void>(
+    context: context,
+    barrierDismissible: false, // user must tap button!
+    builder: (_) {
+      return AlertDialog(
+        title: Text(title),
+        content: SingleChildScrollView(
+          child: child,
+        ),
+        actions: actionButtons,
+      );
+    },
+  );
+}
 }

--- a/lib/styles/AppColors.dart
+++ b/lib/styles/AppColors.dart
@@ -2,9 +2,12 @@ import 'package:flutter/material.dart';
 class AppColors {
 static Color primary = Colors.pink[800];
 static Color secondary = Colors.blueGrey;
+static Color info = Colors.blue[800];
 static Color success = Colors.teal;
 static Color danger = Colors.redAccent;
 static Color cardTitle = Colors.grey[700];
 static Color cardText = Colors.grey[500];
 static Color buttonText = Colors.grey[300];
+static Color winner = Colors.amber;
+static const Color transparent = Color(0x00000000);
 }

--- a/lib/widgets/Avatar/Avatar.dart
+++ b/lib/widgets/Avatar/Avatar.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class Avatar extends StatelessWidget {
+  const Avatar({@required this.avatar, @required this.isBig});
+
+  final NetworkImage avatar;
+  final bool isBig;
+
+  @override
+  Widget build (BuildContext context) {
+    return CircleAvatar(
+      radius: isBig ? 20.0 : 7.5,
+      backgroundImage: avatar,
+    );
+  }
+}

--- a/lib/widgets/BetCard/BetActions.dart
+++ b/lib/widgets/BetCard/BetActions.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:long_term_bets/data/ActionButton.dart';
+import 'package:long_term_bets/data/Bets.dart';
+import 'package:long_term_bets/data/IconStyle.dart';
+import 'package:long_term_bets/mixins/WidgetHelper.dart';
+import 'package:long_term_bets/styles/AppColors.dart';
+import 'package:long_term_bets/widgets/BetCard/WinnerPicker.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+
+class BetActionsState extends State<BetActions> with WidgetHelper{
+  BetActionsState({@required this.bets, @required this.bet, @required this.mainContext});
+
+  final Bets bets;
+  final Bet bet;
+  final BuildContext mainContext;
+
+  Better _selected;
+
+  final Color _contentColor = AppColors.buttonText;
+  final bool _isFlat = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = bet.better;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: _actionButtons().map((ActionButton button) {
+        return Padding(
+          padding: const EdgeInsets.all(5.0),
+          child:button.generateButton()
+        );
+      }).toList()
+    );
+  }
+
+  void _setSelected(Better value) {
+   setState(() {
+    _selected = value;
+   });
+  }
+
+  ActionButton _createActionButton(
+    String text,
+    Color background,
+    IconData icon,
+    Function onPressed,
+    ) {
+    return ActionButton(
+      text: text,
+      textColor: _contentColor,
+      color: background,
+      iconStyle: IconStyle(color: _contentColor, icon: icon),
+      isFlat: _isFlat,
+      onPressed: onPressed,
+    );
+  }
+
+  ActionButton _editButton() {
+    final Function pressFn = (){};
+
+    return _createActionButton('Edit', AppColors.secondary, Icons.edit, pressFn);
+  }
+
+  ActionButton _deleteButon() {
+    final Function pressFn = () {
+      bets.delete(bet);
+      Navigator.pop(mainContext);
+    };
+
+    return _createActionButton(
+      'Delete',
+      AppColors.danger,
+      Icons.delete_forever,
+      pressFn,
+    );
+  }
+
+  ActionButton _setWinnerButton() {
+    final Function pressFn = () {
+      bets.markAsCompleted(bet, _selected);
+    };
+    return _createActionButton('Confirm', AppColors.success, MdiIcons.trophy, pressFn);
+  }
+
+  ActionButton _setProgressButton() {
+
+    if (!bet.isCompleted()) {
+      final WinnerPicker winnerPicker = WinnerPicker(
+        accepter: bet.accepter,
+        better: bet.better,
+        context: mainContext,
+        onChanged: _setSelected,
+      );
+      final Function pressFn = () {
+        showAlert(
+          mainContext,
+          '🤓 Who Won?',
+          winnerPicker,
+          <ActionButton>[_setWinnerButton()]
+        );
+      };
+
+      return _createActionButton('Done', AppColors.success, Icons.check_circle, pressFn);
+    } else {
+      final Function pressFn = () => bets.markAsRunning(bet);
+
+      return _createActionButton(
+        'Running',
+        AppColors.info,
+        Icons.directions_run,
+        pressFn,
+      );
+    }
+  }
+
+  List<ActionButton> _actionButtons() {
+    return <ActionButton>[
+      _setProgressButton(),
+      _editButton(),
+      _deleteButon(),
+    ];
+  }
+}
+
+class BetActions extends StatefulWidget {
+  const BetActions({@required this.bets, @required this.bet, @required this.mainContext});
+
+  final Bets bets;
+  final Bet bet;
+  final BuildContext mainContext;
+
+  @override
+  BetActionsState createState() => BetActionsState(
+    bets: bets,
+    bet: bet,
+    mainContext: mainContext
+  );
+}

--- a/lib/widgets/BetCard/BetCard.dart
+++ b/lib/widgets/BetCard/BetCard.dart
@@ -4,6 +4,7 @@ import 'package:long_term_bets/consumers/BetterConsumer.dart';
 import 'package:long_term_bets/data/Bets.dart';
 import 'package:long_term_bets/providers/BetProvider.dart';
 import 'package:long_term_bets/styles/AppColors.dart';
+import 'package:long_term_bets/widgets/Avatar/Avatar.dart';
 import 'package:long_term_bets/widgets/BetCard/BetTooltips.dart';
 import 'package:long_term_bets/mixins/WidgetHelper.dart';
 import 'package:long_term_bets/widgets/BetCard/BetPopUp.dart';
@@ -45,7 +46,7 @@ class BetCard extends StatelessWidget with
           children: <Widget>[
             buildDividedContainer(
               true,
-              otherSide.avatar,
+              Avatar(avatar: otherSide.avatar, isBig: true),
             )
           ],
         ),

--- a/lib/widgets/BetCard/BetPopUp.dart
+++ b/lib/widgets/BetCard/BetPopUp.dart
@@ -2,15 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:long_term_bets/consumers/BetConsumer.dart';
 import 'package:long_term_bets/consumers/BetsConsumer.dart';
-import 'package:long_term_bets/consumers/BetterConsumer.dart';
-import 'package:long_term_bets/data/ActionButton.dart';
 import 'package:long_term_bets/data/Bets.dart';
-import 'package:long_term_bets/data/IconStyle.dart';
-import 'package:long_term_bets/styles/AppColors.dart';
+import 'package:long_term_bets/mixins/WidgetHelper.dart';
+import 'package:long_term_bets/widgets/BetCard/BetActions.dart';
 import 'package:long_term_bets/widgets/BetCard/Betters.dart';
 import 'BetTooltips.dart';
 
-class BetPopUp extends StatelessWidget with BetsConsumer, BetConsumer, BetterConsumer {
+class BetPopUp extends StatelessWidget with WidgetHelper, BetsConsumer, BetConsumer {
   BetPopUp({ @required this.isCompletedList, @required this.mainContext });
 
   final bool isCompletedList;
@@ -20,72 +18,14 @@ class BetPopUp extends StatelessWidget with BetsConsumer, BetConsumer, BetterCon
   Widget build(BuildContext context) {
     final Bets bets = consumeBets(mainContext);
     final Bet bet = consumeBet(context);
-    final Better currentUser = consumeBetter(mainContext);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: <Widget>[
-        _bettersAvatars(context, bet, currentUser),
-        _actionButtons(context, bets, bet),
-        BetTooltips(bet: bet, alignment: MainAxisAlignment.center),
+        Betters(better: bet.better, accepter: bet.accepter, mainContext: mainContext),
+        BetActions(mainContext: mainContext, bets: bets, bet: bet),
+        BetTooltips(bet: bet, alignment: WrapAlignment.center),
       ]
     );
-  }
-
-  List<ActionButton> _actionButtonsList(BuildContext context, Bets bets, Bet bet) {
-    final Color contentColor = AppColors.buttonText;
-    final List<ActionButton> actionButtons =  <ActionButton>[
-      ActionButton(
-        text: 'Edit',
-        textColor: contentColor,
-        color: AppColors.primary,
-        iconStyle: IconStyle(color: contentColor, icon: Icons.edit),
-        onPressed: () {},
-      ),
-      ActionButton(
-        text: 'Delete',
-        textColor: contentColor,
-        color: AppColors.danger,
-        iconStyle: IconStyle(color: contentColor, icon: Icons.delete_forever),
-        onPressed: () {
-          bets.delete(bet);
-          Navigator.pop(context);
-        },
-      ),
-    ];
-
-    if (!bet.isCompleted()) {
-      actionButtons.insert(0, ActionButton(
-        text: 'Done',
-        textColor: contentColor,
-        color: AppColors.success,
-        iconStyle: IconStyle(color: contentColor, icon: Icons.check_circle),
-        onPressed: () => bets.markAsCompleted(bet),
-      ));
-    }
-
-    return actionButtons;
-  }
-
-  Widget _actionButtons(BuildContext context, Bets bets, Bet bet) {
-    final List<ActionButton> actionButtons = _actionButtonsList(context, bets, bet);
-
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: actionButtons.map((ActionButton button) {
-        return Padding(
-          padding: const EdgeInsets.all(5.0),
-          child:button.generateButton()
-        );
-      }).toList()
-    );
-  }
-
-  Widget _bettersAvatars(BuildContext context, Bet bet, Better currentUser) {
-    return Betters(
-      currentUser: currentUser,
-      better: bet.better,
-      accepter: bet.accepter,
-      );
   }
 }

--- a/lib/widgets/BetCard/BetTooltips.dart
+++ b/lib/widgets/BetCard/BetTooltips.dart
@@ -4,28 +4,37 @@ import 'package:long_term_bets/data/IconStyle.dart';
 import 'package:long_term_bets/mixins/WidgetHelper.dart';
 import 'package:long_term_bets/styles/AppColors.dart';
 import 'package:intl/intl.dart';
-
+import 'package:long_term_bets/widgets/Avatar/Avatar.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
 class BetTooltips extends StatelessWidget with WidgetHelper {
-  BetTooltips({@required this.bet, this.alignment = MainAxisAlignment.start});
+  BetTooltips({@required this.bet, this.alignment = WrapAlignment.start});
 
-  final MainAxisAlignment alignment;
+  final WrapAlignment alignment;
   final Bet bet;
 
   final DateFormat _dateFormatter = DateFormat('MMM yyyy');
   final double _bottomIconsSize = 15.0;
-  final double _iconSpacing = 1.0;
-  final IconStyle _dateIconStyle = IconStyle(
-    icon: Icons.date_range,
+  final double _iconSpacing = 2.0;
+  final IconStyle _expiryDateIconStyle = IconStyle(
+    icon: Icons.event,
+    color: AppColors.secondary,
+  );
+  final IconStyle _completedDateIconStyle = IconStyle(
+    icon: Icons.event_available,
     color: AppColors.secondary,
   );
   final IconStyle _runningIcon = IconStyle(
     icon: Icons.directions_run,
-    color: AppColors.primary,
+    color: AppColors.info,
   );
   final IconStyle _completedIcon = IconStyle(
     icon: Icons.check_circle,
     color: AppColors.success,
+  );
+  final IconStyle _winnerIcon = IconStyle(
+    icon: MdiIcons.trophy,
+    color: AppColors.winner,
   );
   final TextStyle _iconTextStyle = TextStyle(
     color: AppColors.cardText,
@@ -35,44 +44,81 @@ class BetTooltips extends StatelessWidget with WidgetHelper {
 
   @override
   Widget build(BuildContext context) {
+    final List<Widget> tooltips = <Widget>[
+      _stateTooltip(),
+      _dateTooltip(!bet.isCompleted())
+    ];
+    if (bet.isCompleted()) {
+      tooltips.add(_winnerTooltip());
+    }
+
     return Container(
       padding: const EdgeInsets.only(top: 5.0),
-      child: Row(
-        mainAxisAlignment: alignment,
-        children: <Widget>[
-          buildDividedContainer(false, Wrap(
-            spacing: _iconSpacing,
-            children: <Widget>[
-              Icon(
-                bet.isCompleted() ? _completedIcon.icon : _runningIcon.icon,
-                color: bet.isCompleted() ? _completedIcon.color : _runningIcon.color,
-                size: _bottomIconsSize,
-              ),
-              Text(
-                bet.isCompleted() ? 'Completed' : 'Running',
-                style: _iconTextStyle,
-              ),
-            ],
-          )),
-          buildDividedContainer(false, Wrap(
-            spacing: _iconSpacing,
-            children: <Widget>[
-              Icon(
-                _dateIconStyle.icon,
-                color: _dateIconStyle.color,
-                size: _bottomIconsSize,
-              ),
-              Text(
-                _dateFormatter.format(
-                  bet.isCompleted() ?  bet.completionDate : bet.expiryDate,
-                ),
-                style: _iconTextStyle
+      child: Wrap(
+        alignment: alignment,
+        children: tooltips,
+      ),
+    );
+  }
 
-              ),
-            ],
-          ), isLast: true)
+  Widget _stateTooltip() {
+    return buildDividedContainer(false, Wrap(
+      spacing: _iconSpacing,
+      children: <Widget>[
+        Icon(
+          bet.isCompleted() ? _completedIcon.icon : _runningIcon.icon,
+          color: bet.isCompleted() ? _completedIcon.color : _runningIcon.color,
+          size: _bottomIconsSize,
+        ),
+        Text(
+          bet.isCompleted() ? 'Done' : 'Running',
+          style: _iconTextStyle,
+        ),
+      ],
+    ));
+  }
+
+  Widget _dateTooltip(bool isLast) {
+    final IconStyle dateIconStyle = bet.isCompleted() ? _completedDateIconStyle :
+      _expiryDateIconStyle;
+    return buildDividedContainer(
+      false,
+      Wrap(
+        spacing: _iconSpacing,
+        children: <Widget>[
+          Icon(
+            dateIconStyle.icon,
+            color: dateIconStyle.color,
+            size: _bottomIconsSize,
+          ),
+          Text(
+            _dateFormatter.format(
+              bet.isCompleted() ?  bet.completionDate : bet.expiryDate,
+            ),
+            style: _iconTextStyle
+
+          ),
         ],
       ),
+      isLast: isLast
+    );
+  }
+
+  Widget _winnerTooltip() {
+    return buildDividedContainer(
+      false,
+      Wrap(
+        spacing: _iconSpacing,
+        children: <Widget>[
+          Icon(
+            _winnerIcon.icon,
+            color: _winnerIcon.color,
+            size: _bottomIconsSize,
+          ),
+          Avatar(avatar: bet.winner.avatar, isBig: false),
+        ],
+      ),
+      isLast: true
     );
   }
 }

--- a/lib/widgets/BetCard/Betters.dart
+++ b/lib/widgets/BetCard/Betters.dart
@@ -2,24 +2,21 @@ import 'package:flutter/material.dart';
 import 'package:long_term_bets/data/Bets.dart';
 import 'package:long_term_bets/data/IconStyle.dart';
 import 'package:long_term_bets/styles/AppColors.dart';
+import 'package:long_term_bets/widgets/Better/BetterAvatar.dart';
 
 
 class Betters extends StatelessWidget {
-  Betters({@required this.currentUser, @required this.accepter, @required this.better});
+  Betters({@required this.accepter, @required this.better, @required this.mainContext});
 
-  final Better currentUser;
   final Better better;
   final Better accepter;
+  final BuildContext mainContext;
 
   final MainAxisAlignment alignment = MainAxisAlignment.center;
   final double iconSize = 50.0;
   final IconStyle vsIconStyle = IconStyle(
     color: AppColors.secondary,
     icon: Icons.compare_arrows
-  );
-  final TextStyle _avatarTextStyle = TextStyle(
-    color: AppColors.secondary,
-    fontWeight: FontWeight.bold
   );
 
   @override
@@ -41,10 +38,12 @@ class Betters extends StatelessWidget {
   Widget _avatar(Better better) {
     return Padding(
       padding: const EdgeInsets.all(5.0),
-      child: Column(children: <Widget>[
-        better.avatar,
-        Text(better == currentUser ? 'You' : better.name, style: _avatarTextStyle)
-      ])
+      child: BetterAvatar(
+        better: better,
+        isBig: true,
+        mainContext: mainContext,
+        isVertical: true,
+      )
     );
   }
 }

--- a/lib/widgets/BetCard/WinnerPicker.dart
+++ b/lib/widgets/BetCard/WinnerPicker.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:long_term_bets/data/Bets.dart';
+import 'package:long_term_bets/styles/AppColors.dart';
+import 'package:long_term_bets/widgets/Better/BetterAvatar.dart';
+
+class WinnerPickerState extends State<WinnerPicker> {
+  WinnerPickerState({
+    @required this.better,
+    @required this.accepter,
+    @required this.mainContext,
+    @required this.onChanged,
+  });
+
+  final Better better;
+  final Better accepter;
+  final BuildContext mainContext;
+  final Function(Better) onChanged;
+  Better _selected;
+
+  final bool _isBigAvatar = false;
+  final bool _isVertical = false;
+  final Color _activeColor = AppColors.info;
+
+  void _setSelected(Better value) {
+   setState(() {
+    _selected = value;
+   });
+   onChanged(value);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = better;
+  }
+
+  @override
+  Widget build (BuildContext context) {
+    return Column(
+    children: <Widget>[
+    RadioListTile<Better>(
+      activeColor: _activeColor,
+      title: BetterAvatar(
+        mainContext: mainContext,
+        better: better,
+        isBig: _isBigAvatar,
+        isVertical: _isVertical,
+      ),
+      value: better,
+      groupValue: _selected,
+      onChanged: _setSelected,
+    ),
+    RadioListTile<Better>(
+      activeColor: _activeColor,
+      title: BetterAvatar(
+        mainContext: mainContext,
+        better: accepter,
+        isBig: _isBigAvatar,
+        isVertical: _isVertical,
+      ),
+      value: accepter,
+      groupValue: _selected,
+      onChanged: _setSelected,
+    ),
+  ],
+);
+  }
+}
+
+class WinnerPicker extends StatefulWidget {
+  const WinnerPicker({
+    @required this.better,
+    @required this.accepter,
+    @required this.context,
+    @required this.onChanged,
+  });
+
+  final Better better;
+  final Better accepter;
+  final Function(Better) onChanged;
+  final BuildContext context;
+
+
+  @override
+  WinnerPickerState createState() => WinnerPickerState(
+    better: better,
+    accepter: accepter,
+    mainContext: context,
+    onChanged: onChanged
+  );
+}

--- a/lib/widgets/Better/BetterAvatar.dart
+++ b/lib/widgets/Better/BetterAvatar.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:long_term_bets/consumers/BetterConsumer.dart';
+import 'package:long_term_bets/data/Bets.dart';
+import 'package:long_term_bets/styles/AppColors.dart';
+import 'package:long_term_bets/widgets/Avatar/Avatar.dart';
+
+class BetterAvatar extends StatelessWidget with BetterConsumer {
+  BetterAvatar({
+  @required this.better,
+   @required this.isBig,
+   @required this.isVertical,
+   this.mainContext,
+  });
+
+  final Better better;
+  final bool isBig;
+  final bool isVertical;
+  final BuildContext mainContext;
+
+  final TextStyle _avatarTextStyle = TextStyle(
+    color: AppColors.secondary,
+    fontWeight: FontWeight.bold
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final Better currentUser = consumeBetter(mainContext != null ? mainContext : context);
+
+    return Wrap(
+      direction: isVertical ? Axis.vertical : Axis.horizontal,
+      alignment: WrapAlignment.start,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      spacing: isVertical ? 0.0 : 5.0,
+      children: <Widget>[
+        Avatar(avatar: better.avatar, isBig: isBig),
+        Text(better == currentUser ? 'You' : better.name, style: _avatarTextStyle)
+      ]);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -67,6 +67,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.5"
+  material_design_icons_flutter:
+    dependency: "direct main"
+    description:
+      name: material_design_icons_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.2.3695"
   meta:
     dependency: transitive
     description:
@@ -165,3 +172,4 @@ packages:
     version: "2.0.8"
 sdks:
   dart: ">=2.2.0 <3.0.0"
+  flutter: ">=0.1.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   cupertino_icons: ^0.1.2
   english_words: ^3.1.0
   provider: ^3.0.0+1
+  material_design_icons_flutter: 3.2.3695
   intl: ^0.15.8
 
 dev_dependencies:


### PR DESCRIPTION
###### **please follow the guidlines mentioned below and  fill all the sections for a smoother PR 🤗**

##### Make sure **if needed** that you:
* [x] wrote a clear description of the pr ( see below :arrow_down: )
* [x] followed our current commits and branching scheme ( please check [contributing.md](../contributing.md)
* [x] rebased your code on top of master
* [ ] wrote tests for your introduced code
* [ ] updated any existing tests to work with your new code
* [x] made sure all strings are typo **free**


### Description:
#### 📰 please write a clear description of what this PR is about
Add the ability to choose a winner when marking a bet as completed. Also add the ability to mark a bet as running again after marking it as done.

### Changes
##### 📱 Flutter related
* Add winner to Bet class
* Add ability to mark completed bet as running
* Adjust colors of tooltips and buttons
* Add material design icons package
* Change Avatar to be a network image instead of Avatar widget
* Add Avatar Widget
* Change BetTooltips to use wrap instead of row for responsiveness
* Add winner icon / color
* Add BetterAvatar Widget
* Add transparent color
* Add showAlert function to WidgetHelper
* Add WinnerPicker StatefulWidget
* Add isFlat option to ActionButton
* Move BetActions to their own StatefulWidget

### 🙄 is there anything controversial about your code ?
No :+1: 