### PR TITLE
Show snackbar when deleting a bet and add swipe actions

### DIFF
--- a/lib/consumers/BetConsumer.dart
+++ b/lib/consumers/BetConsumer.dart
@@ -2,6 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:long_term_bets/data/Bets.dart';
 import 'package:provider/provider.dart';
 
-mixin BetConsumer on Widget{
+mixin BetConsumer{
   Bet consumeBet(BuildContext context) => Provider.of<Bet>(context);
 }

--- a/lib/consumers/BetsConsumer.dart
+++ b/lib/consumers/BetsConsumer.dart
@@ -9,7 +9,7 @@ enum BetsType {
   lost
 }
 
-mixin BetsConsumer on Widget {
+mixin BetsConsumer {
   Bets consumeBets(BuildContext context) => Provider.of<Bets>(context);
 
   List<Bet> betsList(BuildContext context, BetsType type) {

--- a/lib/consumers/BetterConsumer.dart
+++ b/lib/consumers/BetterConsumer.dart
@@ -2,6 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:long_term_bets/data/Bets.dart';
 import 'package:provider/provider.dart';
 
-mixin BetterConsumer on Widget {
+mixin BetterConsumer {
   Better consumeBetter(BuildContext context) => Provider.of<Better>(context);
 }

--- a/lib/data/Bets.dart
+++ b/lib/data/Bets.dart
@@ -114,6 +114,22 @@ class Bets with ChangeNotifier {
 
     notifyListeners();
   }
+
+
+  void add(Bet bet, Better currentUser, {int index = -1}) {
+    _allBets.add(bet);
+    if(bet.isCompleted()) {
+      if (bet.winner == currentUser) {
+        _wonBets.add(bet);
+      } else {
+        _lostBets.add(bet);
+      }
+    } else {
+      _runningBets.add(bet);
+    }
+
+    notifyListeners();
+  }
 }
 
 class Bet with ChangeNotifier {

--- a/lib/mixins/WidgetHelper.dart
+++ b/lib/mixins/WidgetHelper.dart
@@ -48,38 +48,46 @@ mixin WidgetHelper {
     );
   }
 
-Future<void> showAlert(
-  BuildContext context,
-  String title,
-  Widget child,
-  List<ActionButton> actions,
-) async {
-  final Function dismissAlert = () => Navigator.of(context).pop();
+  Future<void> showAlert(
+    BuildContext context,
+    String title,
+    Widget child,
+    List<ActionButton> actions,
+  ) async {
+    final Function dismissAlert = () => Navigator.of(context).pop();
 
-  final List<ButtonTheme> actionButtons = actions.map((ActionButton button) =>
-    button.generateButton(callback: dismissAlert)
-  ).toList();
+    final List<ButtonTheme> actionButtons = actions.map((ActionButton button) =>
+      button.generateButton(callback: dismissAlert)
+    ).toList();
 
-  actionButtons.add(ActionButton(
-    isFlat: true,
-    onPressed: dismissAlert,
-    text: 'Discard',
-    color: AppColors.transparent,
-    iconStyle: IconStyle(icon: AppIcons.back, color: AppColors.buttonText)
+    actionButtons.add(ActionButton(
+      isFlat: true,
+      onPressed: dismissAlert,
+      text: 'Discard',
+      color: AppColors.transparent,
+      iconStyle: IconStyle(icon: AppIcons.back, color: AppColors.buttonText)
     ).generateButton());
 
-  return showDialog<void>(
-    context: context,
-    barrierDismissible: false, // user must tap button!
-    builder: (_) {
-      return AlertDialog(
-        title: Text(title),
-        content: SingleChildScrollView(
-          child: child,
-        ),
-        actions: actionButtons,
-      );
-    },
-  );
-}
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false, // user must tap button!
+      builder: (_) {
+        return AlertDialog(
+          title: Text(title),
+          content: SingleChildScrollView(
+            child: child,
+          ),
+          actions: actionButtons,
+        );
+      },
+    );
+  }
+
+  void showSnackBar(String text, BuildContext context, {SnackBarAction action} ) {
+    final Widget snackBar = SnackBar(
+      content: Text(text),
+      action: action,
+    );
+    Scaffold.of(context).showSnackBar(snackBar);
+  }
 }

--- a/lib/providers/BetProvider.dart
+++ b/lib/providers/BetProvider.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:long_term_bets/consumers/BetConsumer.dart';
 import 'package:long_term_bets/data/Bets.dart';
 import 'package:provider/provider.dart';
 
 mixin BetProvider {
-  Widget provideBet(Bet bet, BetConsumer child) {
+  Widget provideBet(Bet bet, Widget child) {
     return ChangeNotifierProvider<Bet>.value(
       value: bet,
       child: child

--- a/lib/providers/BetsProvider.dart
+++ b/lib/providers/BetsProvider.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:long_term_bets/consumers/BetsConsumer.dart';
 import 'package:long_term_bets/data/Bets.dart';
 import 'package:provider/provider.dart';
 
 mixin BetsProvider {
-  Widget provideBets(Bets bets, Better better, BetsConsumer child) {
+  Widget provideBets(Bets bets, Better better, Widget child) {
     return MultiProvider(
       providers: <SingleChildCloneableWidget>[
         ChangeNotifierProvider<Bets>(builder: (_) => bets),

--- a/lib/widgets/BetCard/BetActionButtons.dart
+++ b/lib/widgets/BetCard/BetActionButtons.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:long_term_bets/data/ActionButton.dart';
+import 'package:long_term_bets/data/Bets.dart';
+import 'package:long_term_bets/styles/AppColors.dart';
+import 'package:long_term_bets/styles/AppIcons.dart';
+import 'package:long_term_bets/styles/AppSizes.dart';
+import 'package:long_term_bets/widgets/BetCard/BetActions.dart';
+
+class BetActionButtonsState extends BetActionsState<BetActionButtons> {
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: _actionButtons().map((ActionButton button) {
+        return Padding(
+          padding:  EdgeInsets.all(AppSizes.widgetMargin),
+          child:button.generateButton()
+        );
+      }).toList()
+    );
+  }
+
+  ActionButton _editButton() {
+    return createActionButton('Edit', AppColors.secondary, AppIcons.edit, editBet);
+  }
+
+  ActionButton _deleteButon() {
+    return createActionButton(
+      'Delete',
+      AppColors.danger,
+      AppIcons.delete,
+      () {
+        deleteBet();
+        Navigator.pop(widget.mainContext);
+      },
+    );
+  }
+
+  ActionButton _setProgressButton() {
+    if (!widget.bet.isCompleted()) {
+      return createActionButton(
+        'Done',
+        AppColors.success,
+        AppIcons.completedBets,
+        markBetAsDone,
+      );
+    } else {
+
+      return createActionButton(
+        'Running',
+        AppColors.info,
+        AppIcons.runningBets,
+        markBetAsRunning,
+      );
+    }
+  }
+
+  List<ActionButton> _actionButtons() {
+    return <ActionButton>[
+      _setProgressButton(),
+      _editButton(),
+      _deleteButon(),
+    ];
+  }
+}
+
+class BetActionButtons extends BetActions {
+  BetActionButtons({
+    @required Bets bets,
+    @required Bet bet,
+    @required BuildContext mainContext,
+  }): super(
+    bets: bets,
+    bet: bet,
+    mainContext: mainContext
+  );
+
+  @override
+  BetActionButtonsState createState() => BetActionButtonsState();
+}

--- a/lib/widgets/BetCard/BetActions.dart
+++ b/lib/widgets/BetCard/BetActions.dart
@@ -1,43 +1,32 @@
 import 'package:flutter/material.dart';
+import 'package:long_term_bets/consumers/BetterConsumer.dart';
 import 'package:long_term_bets/data/ActionButton.dart';
 import 'package:long_term_bets/data/Bets.dart';
 import 'package:long_term_bets/data/IconStyle.dart';
 import 'package:long_term_bets/mixins/WidgetHelper.dart';
 import 'package:long_term_bets/styles/AppColors.dart';
 import 'package:long_term_bets/styles/AppIcons.dart';
-import 'package:long_term_bets/styles/AppSizes.dart';
 import 'package:long_term_bets/widgets/BetCard/WinnerPicker.dart';
 
-class BetActionsState extends State<BetActions> with WidgetHelper{
-  BetActionsState({@required this.bets, @required this.bet, @required this.mainContext});
-
-  final Bets bets;
-  final Bet bet;
-  final BuildContext mainContext;
-
+abstract class BetActionsState<T extends BetActions> extends State<T> with
+  WidgetHelper,
+  BetterConsumer
+{
   Better _selected;
+  Better _currentUser;
 
-  final Color _contentColor = AppColors.buttonText;
-  final bool _isFlat = false;
+  final Color contentColor = AppColors.buttonText;
+  final bool isFlat = false;
 
   @override
   void initState() {
     super.initState();
-    _selected = bet.better;
+    _selected = widget.bet.better;
+    _currentUser = consumeBetter(widget.mainContext);
   }
 
   @override
-  Widget build(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: _actionButtons().map((ActionButton button) {
-        return Padding(
-          padding:  EdgeInsets.all(AppSizes.widgetMargin),
-          child:button.generateButton()
-        );
-      }).toList()
-    );
-  }
+  Widget build(BuildContext context);
 
   void _setSelected(Better value) {
    setState(() {
@@ -45,7 +34,7 @@ class BetActionsState extends State<BetActions> with WidgetHelper{
    });
   }
 
-  ActionButton _createActionButton(
+  ActionButton createActionButton(
     String text,
     Color background,
     IconData icon,
@@ -54,95 +43,62 @@ class BetActionsState extends State<BetActions> with WidgetHelper{
     return ActionButton(
       text: text,
       color: background,
-      iconStyle: IconStyle(color: _contentColor, icon: icon),
-      isFlat: _isFlat,
+      iconStyle: IconStyle(color: contentColor, icon: icon),
+      isFlat: isFlat,
       onPressed: onPressed,
     );
   }
 
-  ActionButton _editButton() {
-    final Function pressFn = (){};
+  void editBet() {}
 
-    return _createActionButton('Edit', AppColors.secondary, AppIcons.edit, pressFn);
-  }
-
-  ActionButton _deleteButon() {
-    final Function pressFn = () {
-      bets.delete(bet);
-      Navigator.pop(mainContext);
-    };
-
-    return _createActionButton(
-      'Delete',
-      AppColors.danger,
-      AppIcons.delete,
-      pressFn,
+  void deleteBet() {
+    widget.bets.delete(widget.bet);
+    showSnackBar(
+      'Bet deleted!',
+      widget.mainContext,
+      action: SnackBarAction(
+        label: 'undo',
+        onPressed: () => widget.bets.add(widget.bet, _currentUser),
+      ),
     );
   }
 
   ActionButton _setWinnerButton() {
     final Function pressFn = () {
-      bets.markAsCompleted(bet, _selected);
+      widget.bets.markAsCompleted(widget.bet, _selected);
     };
-    return _createActionButton('Confirm', AppColors.success, AppIcons.betWinner, pressFn);
+    return createActionButton('Confirm', AppColors.success, AppIcons.betWinner, pressFn);
   }
 
-  ActionButton _setProgressButton() {
+  void markBetAsRunning() => widget.bets.markAsRunning(widget.bet);
 
-    if (!bet.isCompleted()) {
-      final WinnerPicker winnerPicker = WinnerPicker(
-        accepter: bet.accepter,
-        better: bet.better,
-        context: mainContext,
-        onChanged: _setSelected,
-      );
-      final Function pressFn = () {
-        showAlert(
-          mainContext,
-          '🤓 Who Won?',
-          winnerPicker,
-          <ActionButton>[_setWinnerButton()]
-        );
-      };
-
-      return _createActionButton(
-        'Done',
-        AppColors.success,
-        AppIcons.completedBets,
-        pressFn,
-      );
-    } else {
-      final Function pressFn = () => bets.markAsRunning(bet);
-
-      return _createActionButton(
-        'Running',
-        AppColors.info,
-        AppIcons.runningBets,
-        pressFn,
-      );
-    }
-  }
-
-  List<ActionButton> _actionButtons() {
-    return <ActionButton>[
-      _setProgressButton(),
-      _editButton(),
-      _deleteButon(),
-    ];
+  void markBetAsDone() {
+    final WinnerPicker winnerPicker = WinnerPicker(
+      accepter: widget.bet.accepter,
+      better: widget.bet.better,
+      context: widget.mainContext,
+      onChanged: _setSelected,
+    );
+    showAlert(
+      widget.mainContext,
+      '🤓 Who Won?',
+      winnerPicker,
+      <ActionButton>[_setWinnerButton()]
+    );
   }
 }
 
-class BetActions extends StatefulWidget {
-  const BetActions({@required this.bets, @required this.bet, @required this.mainContext});
+abstract class BetActions extends StatefulWidget {
+  BetActions({
+    @required this.bets,
+    @required this.bet,
+    @required this.mainContext,
+  }): super(key: UniqueKey());
 
   final Bets bets;
   final Bet bet;
   final BuildContext mainContext;
 
   @override
-  BetActionsState createState() => BetActionsState(
-    bets: bets,
-    bet: bet,
-    mainContext: mainContext
-  );
+  BetActionsState createState();
 }

--- a/lib/widgets/BetCard/BetCard.dart
+++ b/lib/widgets/BetCard/BetCard.dart
@@ -9,6 +9,8 @@ import 'package:long_term_bets/styles/AppIcons.dart';
 import 'package:long_term_bets/styles/AppSizes.dart';
 import 'package:long_term_bets/styles/TextStyles.dart';
 import 'package:long_term_bets/widgets/Avatar/Avatar.dart';
+import 'package:long_term_bets/widgets/BetCard/BetActions.dart';
+import 'package:long_term_bets/widgets/BetCard/BetSlidable.dart';
 import 'package:long_term_bets/widgets/BetCard/BetTooltips.dart';
 import 'package:long_term_bets/mixins/WidgetHelper.dart';
 import 'package:long_term_bets/widgets/BetCard/BetPopUp.dart';
@@ -17,25 +19,29 @@ class BetCard extends StatelessWidget with
   WidgetHelper,
   BetterConsumer,
   BetConsumer,
+  BetsConsumer,
   BetProvider
 {
-  BetCard({@required this.betsType});
-
-  final BetsType betsType;
-
   final Color _iconColor = AppColors.secondary;
 
   @override
   Widget build(BuildContext context) {
+    final Bet bet = consumeBet(context);
+    final Bets bets = consumeBets(context);
+
     return Card(
       elevation: AppSizes.elevation,
       margin: EdgeInsets.symmetric(vertical: AppSizes.widgetMargin),
-      child: _buildTile(context),
+      child: BetSlidable(
+        bets: bets,
+        bet: bet,
+        mainContext: context,
+        card: _buildTile(context, bet),
+      )
     );
   }
 
-  ListTile _buildTile(BuildContext context) {
-    final Bet bet = consumeBet(context);
+  ListTile _buildTile(BuildContext context, Bet bet) {
     final Better currentUser = consumeBetter(context);
     final Better otherSide = bet.getOtherSide(currentUser);
 
@@ -58,7 +64,7 @@ class BetCard extends StatelessWidget with
           style: TextStyles.titleStyle,
           maxLines: 2,
         ),
-        subtitle: BetTooltips(bet: bet, currentUser: currentUser),
+        subtitle: BetTooltips(bet: bet),
         trailing: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
@@ -81,7 +87,6 @@ class BetCard extends StatelessWidget with
                 ),
               )
             )
-
           ]
         )
     );

--- a/lib/widgets/BetCard/BetPopUp.dart
+++ b/lib/widgets/BetCard/BetPopUp.dart
@@ -2,21 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:long_term_bets/consumers/BetConsumer.dart';
 import 'package:long_term_bets/consumers/BetsConsumer.dart';
-import 'package:long_term_bets/consumers/BetterConsumer.dart';
 import 'package:long_term_bets/data/Bets.dart';
 import 'package:long_term_bets/mixins/WidgetHelper.dart';
 import 'package:long_term_bets/styles/AppSizes.dart';
-import 'package:long_term_bets/widgets/BetCard/BetActions.dart';
 import 'package:long_term_bets/widgets/BetCard/BetDetails.dart';
 import 'package:long_term_bets/widgets/BetCard/Betters.dart';
+import 'BetActionButtons.dart';
 import 'BetTooltips.dart';
 
-class BetPopUp extends StatelessWidget with
-  WidgetHelper,
-  BetsConsumer,
-  BetConsumer,
-  BetterConsumer
-{
+class BetPopUp extends StatelessWidget with WidgetHelper, BetsConsumer, BetConsumer {
   BetPopUp({ @required this.mainContext });
 
   final BuildContext mainContext;
@@ -25,7 +19,6 @@ class BetPopUp extends StatelessWidget with
   Widget build(BuildContext context) {
     final Bets bets = consumeBets(mainContext);
     final Bet bet = consumeBet(context);
-    final Better currentUser = consumeBetter(mainContext);
 
     return SingleChildScrollView(
       child: Padding(
@@ -34,8 +27,8 @@ class BetPopUp extends StatelessWidget with
           crossAxisAlignment: CrossAxisAlignment.center,
           children: <Widget>[
             Betters(better: bet.better, accepter: bet.accepter, mainContext: mainContext),
-            BetActions(mainContext: mainContext, bets: bets, bet: bet),
-            BetTooltips(bet: bet, alignment: WrapAlignment.center, currentUser: currentUser),
+            BetActionButtons(mainContext: mainContext, bets: bets, bet: bet),
+            BetTooltips(bet: bet, alignment: WrapAlignment.center, context: mainContext),
             horizontalDivider(),
             BetDetails(bet: bet),
           ]

--- a/lib/widgets/BetCard/BetSlidable.dart
+++ b/lib/widgets/BetCard/BetSlidable.dart
@@ -1,0 +1,54 @@
+
+import 'package:flutter/material.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
+import 'package:long_term_bets/data/Bets.dart';
+import 'package:long_term_bets/styles/AppColors.dart';
+import 'package:long_term_bets/styles/AppIcons.dart';
+import 'package:long_term_bets/widgets/BetCard/BetActions.dart';
+
+class BetSlidableState<T extends BetSlidable> extends BetActionsState<BetSlidable> {
+
+  @override
+  Widget build(BuildContext context) {
+    return Slidable(
+        actionPane: const SlidableDrawerActionPane(),
+        actionExtentRatio: 0.25,
+        child: widget.card,
+        actions: <Widget>[
+          IconSlideAction(
+            color: widget.bet.isCompleted() ? AppColors.info : AppColors.success,
+            icon: widget.bet.isCompleted() ? AppIcons.runningBets : AppIcons.completedBets,
+            foregroundColor: AppColors.buttonText,
+            onTap: () => widget.bet.isCompleted() ? markBetAsRunning() : markBetAsDone(),
+
+          ),
+        ],
+        secondaryActions: <Widget>[
+          IconSlideAction(
+            color: AppColors.danger,
+            icon: AppIcons.delete,
+            foregroundColor: AppColors.buttonText,
+            onTap: () => deleteBet(),
+          ),
+        ],
+      );
+  }
+}
+
+class BetSlidable extends BetActions {
+  BetSlidable({
+    @required Bets bets,
+    @required Bet bet,
+    @required BuildContext mainContext,
+    @required this.card,
+  }): super(
+    bets: bets,
+    bet: bet,
+    mainContext: mainContext
+  );
+
+  final Widget card;
+
+  @override
+  BetSlidableState createState() =>  BetSlidableState();
+}

--- a/lib/widgets/BetCard/BetTooltips.dart
+++ b/lib/widgets/BetCard/BetTooltips.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:long_term_bets/consumers/BetterConsumer.dart';
 import 'package:long_term_bets/data/Bets.dart';
 import 'package:long_term_bets/data/IconStyle.dart';
 import 'package:long_term_bets/mixins/WidgetHelper.dart';
@@ -9,16 +10,16 @@ import 'package:long_term_bets/styles/AppSizes.dart';
 import 'package:long_term_bets/styles/TextStyles.dart';
 import 'package:long_term_bets/widgets/Avatar/Avatar.dart';
 
-class BetTooltips extends StatelessWidget with WidgetHelper {
+class BetTooltips extends StatelessWidget with WidgetHelper, BetterConsumer {
   BetTooltips({
     @required this.bet,
-    @required this.currentUser,
-    this.alignment = WrapAlignment.start
+    this.alignment = WrapAlignment.start,
+    this.context,
   });
 
   final WrapAlignment alignment;
   final Bet bet;
-  final Better currentUser;
+  final BuildContext context;
 
   final DateFormat _dateFormatter = DateFormat('MMM yyyy');
   final IconStyle _expiryDateIconStyle = IconStyle(
@@ -44,6 +45,7 @@ class BetTooltips extends StatelessWidget with WidgetHelper {
 
   @override
   Widget build(BuildContext context) {
+    context = this.context != null ? this.context : context;
     final List<Widget> tooltips = <Widget>[
       _stateTooltip(),
       _dateTooltip(!bet.isCompleted())
@@ -108,6 +110,7 @@ class BetTooltips extends StatelessWidget with WidgetHelper {
   }
 
   Widget _winnerTooltip(BuildContext context) {
+    final Better currentUser = consumeBetter(context);
     final String winnerName = (currentUser == bet.winner) ? 'You' : bet.winner.name;
     return buildDividedContainer(
       false,

--- a/lib/widgets/BetCard/WinnerPicker.dart
+++ b/lib/widgets/BetCard/WinnerPicker.dart
@@ -69,12 +69,12 @@ class WinnerPickerState extends State<WinnerPicker> {
 }
 
 class WinnerPicker extends StatefulWidget {
-  const WinnerPicker({
+  WinnerPicker({
     @required this.better,
     @required this.accepter,
     @required this.context,
     @required this.onChanged,
-  });
+  }): super(key: UniqueKey());
 
   final Better better;
   final Better accepter;

--- a/lib/widgets/BetsList/BetsList.dart
+++ b/lib/widgets/BetsList/BetsList.dart
@@ -25,7 +25,7 @@ class BetsList extends StatelessWidget with BetsConsumer, BetProvider {
           if (i < betsToShow.length) {
             return provideBet(
               betsToShow[i],
-              BetCard(betsType: betsType)
+              BetCard()
             );
           }
         });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -48,6 +48,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_slidable:
+    dependency: "direct main"
+    description:
+      name: flutter_slidable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   provider: ^3.0.0+1
   material_design_icons_flutter: 3.2.3695
   intl: ^0.15.8
+  flutter_slidable: "^0.5.3"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
###### **please follow the guidlines mentioned below and  fill all the sections for a smoother PR 🤗**

##### Make sure **if needed** that you:
* [x] wrote a clear description of the pr ( see below :arrow_down: )
* [x] followed our current commits and branching scheme ( please check [contributing.md](../contributing.md)
* [x] rebased your code on top of master
* [ ] wrote tests for your introduced code
* [ ] updated any existing tests to work with your new code
* [x] made sure all strings are typo **free**


### Description:
#### 📰 please write a clear description of what this PR is about
Show snackbar with undo action for bet deletion and add swipe actions to edit and delete widgets.
### Changes

##### 📱 Flutter related
- Add add action to bets
- Remove on Widget option from BetterConsumer mixin
- Get currentUser from provider instead of passing it
- Add showSnackBar function to WidgetHelper
- Show Snackbar when delete button is clicked
- Remove consumers dependence on Widget
- Pass key to all widgets that call super
- Change BetActions to abstract class with just bet interaction logic
- Add flutter_slidable package
- Add BetSliedable widget that extends BetActions
- Add BetActionButtons widget that extends BetActions
- Use BetActionButtons in BetPopUp
- Wrap buildTile with BetSliedable
- Remove betsType from BetCard

### 🙄 is there anything controversial about your code ?
No :+1: 