### PR TITLE
Fix form exit style

### DIFF
--- a/lib/widgets/NewBet/NewBetForm.dart
+++ b/lib/widgets/NewBet/NewBetForm.dart
@@ -117,7 +117,7 @@ class NewBetFormState extends State<NewBetForm> with BetterConsumer, BetsConsume
           payment: _payment,
           expiryDate: _expiry,
           accepter: _better,
-          id: '123123' //TODO: needs to be dynamic from backend!
+          id: '${bets.allBets.length}' //TODO: needs to be dynamic from backend!
         );
 
         bets.add(bet, currentUser);

--- a/lib/widgets/NewBet/NewBetPage.dart
+++ b/lib/widgets/NewBet/NewBetPage.dart
@@ -62,8 +62,16 @@ class NewBetPage extends PageRoute<void> {
     return GestureDetector(
       onTap: () => _close(context),
       child: Container(
+        padding: EdgeInsets.only(
+          right: AppSizes.verticalWidgetPadding,
+          top: AppSizes.horizontalWidgetPadding,
+        ),
         alignment: Alignment.centerRight,
-        child: Icon(AppIcons.exit, color: AppColors.buttonText)
+        child: Icon(
+          AppIcons.exit,
+          color: AppColors.buttonText,
+          size: AppSizes.mediumIconSize,
+        ),
       ),
     );
   }


### PR DESCRIPTION
###### **please follow the guidlines mentioned below and  fill all the sections for a smoother PR 🤗**

##### Make sure **if needed** that you:
* [x] wrote a clear description of the pr ( see below :arrow_down: )
* [x] followed our current commits and branching scheme ( please check [contributing.md](../contributing.md)
* [x] rebased your code on top of master
* [ ] wrote tests for your introduced code
* [ ] updated any existing tests to work with your new code
* [x] made sure all strings are typo **free**


### Description:
#### 📰 please write a clear description of what this PR is about
Right now on iphones the close icon is too far up and very small to be clicked easily so it's been brought down a but and its size was increased. Also the temp id that's been given to the created bet was static which allowed only one bet to be created
### Changes
##### :octocat:  Git  Related

##### 📱 Flutter related
- increase size of add form exit icon
- change position of add form exit icon
- bet id is based on array index instead of static (should still be changed later)

### Steps to test
#### ☕️ please write all the steps required to test your code
- make sure that on iphones exit icon is clickable

### 🙄 is there anything controversial about your code ?
No :+1: 